### PR TITLE
Bio: add a paragraph on building with AI agents

### DIFF
--- a/index.markdown
+++ b/index.markdown
@@ -5,6 +5,8 @@ title: Joel Bond
 
 I'm a software engineer, currently at [Stash](https://www.stash.com). I live in Portland, Oregon with my wife and two kids.
 
+Lately I've been building with AI agents — software that can actually do things on its own, not just answer questions. I run a lot of my own day through one, and it's shown me how much a single person can get done this way. What I care about is doing it carefully: agents that act for you without you losing track of what they're up to.
+
 ### Previously
 
 I have over twelve years of experience developing for the web. I worked on business checking at [Cross River](https://www.crossriver.com). I worked on Roundups and Earn/Found Money at [Acorns](https://www.acorns.com). I did web development for various other companies before that.


### PR DESCRIPTION
Adds one paragraph to the homepage bio, right after the opening line, on what I'm interested in building and why. No other changes.

> Lately I've been building with AI agents — software that can actually do things on its own, not just answer questions. I run a lot of my own day through one, and it's shown me how much a single person can get done this way. What I care about is doing it carefully: agents that act for you without you losing track of what they're up to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)