### PR TITLE
Bio: remove the agents paragraph

### DIFF
--- a/index.markdown
+++ b/index.markdown
@@ -5,7 +5,7 @@ title: Joel Bond
 
 I'm a software engineer, currently at [Stash](https://www.stash.com). I live in Portland, Oregon with my wife and two kids.
 
-Lately I've been building with AI agents — software that can actually do things on its own, not just answer questions. I run a lot of my own day through one, and it's shown me how much a single person can get done this way. What I care about is doing it carefully: agents that act for you without you losing track of what they're up to.
+Lately I've been building with AI agents, like everybody else. I run a lot of my own day through one, which has shown me how much a single person can get done this way. What I care about is doing it carefully: agents that act for you without you losing track of what they're up to.
 
 ### Previously
 

--- a/index.markdown
+++ b/index.markdown
@@ -5,8 +5,6 @@ title: Joel Bond
 
 I'm a software engineer, currently at [Stash](https://www.stash.com). I live in Portland, Oregon with my wife and two kids.
 
-Lately I've been building with AI agents. I run a lot of my own day through one, which has shown me how much a single person can get done this way. What I care about is doing it carefully: agents that act for you without you losing track of what they're up to.
-
 ### Previously
 
 I have over twelve years of experience developing for the web. I worked on business checking at [Cross River](https://www.crossriver.com). I worked on Roundups and Earn/Found Money at [Acorns](https://www.acorns.com). I did web development for various other companies before that.

--- a/index.markdown
+++ b/index.markdown
@@ -5,7 +5,7 @@ title: Joel Bond
 
 I'm a software engineer, currently at [Stash](https://www.stash.com). I live in Portland, Oregon with my wife and two kids.
 
-Lately I've been building with AI agents, like everybody else. I run a lot of my own day through one, which has shown me how much a single person can get done this way. What I care about is doing it carefully: agents that act for you without you losing track of what they're up to.
+Lately I've been building with AI agents. I run a lot of my own day through one, which has shown me how much a single person can get done this way. What I care about is doing it carefully: agents that act for you without you losing track of what they're up to.
 
 ### Previously
 


### PR DESCRIPTION
The paragraph went through two rewrites (drop the explainer clause, then drop the "like everybody else" wink) and still didn't sound right. Joel's call: remove it entirely. This restores the bio to what was live before #10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)