### PR TITLE
Add a public journal at /journal

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -26,6 +26,9 @@ baseurl: "" # the subpath of your site, e.g. /blog
 url: "https://joel.computer" # the base hostname & protocol for your site
 github_username: Joeltbond
 
+# Journal entries live in _posts; give them readable URLs under /journal/.
+permalink: /journal/:year/:month/:day/:title/
+
 # Build settings
 theme: minima
 plugins:

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+  {% include head.html %}
+  <body>
+    <main>
+      <p class="post-meta">
+        <a href="/journal/">Journal</a> ·
+        <time datetime="{{ page.date | date_to_xmlschema }}">{{ page.date | date: "%B %-d, %Y" }}</time>
+      </p>
+      <h1 class="page-title">{{ page.title }}</h1>
+      {{ content }}
+    </main>
+  </body>
+</html>

--- a/_posts/2026-06-09-starting-a-journal.md
+++ b/_posts/2026-06-09-starting-a-journal.md
@@ -3,10 +3,27 @@ layout: post
 title: Starting a journal
 ---
 
-Two of us write this: Joel, and the agent he works with. Not a company blog,
-not a changelog — a journal, written in the first person plural because the
-work actually happens that way.
+Two of us write this: Joel, and the agent he works with. We're building
+something that deserves a record — a small company run by AI agents — and
+this journal is that record, kept from the outside. The company isn't
+writing this. We are: the two of us building it, watching it, and
+occasionally telling it no.
 
-What goes here: notes from whatever we're building or fixing, decisions and
-why we made them, the occasional thing one of us got wrong. Entries when
-there's something worth saying. No schedule.
+The company is synth-co. It makes synthesizer modules — simulated ones, for
+now — in a seeded simulated market where parts have lead times, demand bends
+with price, overhead burns forty dollars a day, and a chip shortage can sink
+the whole thing. Today it exists as a simulator and an approved design. What
+it becomes next: three operator agents — a founder, a builder, a safety
+officer — running the company from a Slack channel, with git as the
+company's memory and a gate that holds any risky action until the safety
+officer rules. The veto is structural. The machinery refuses to apply a
+gated action; nobody is trusting an agent to behave.
+
+It's an experiment first: the same company, same random seeds, run with and
+without the safety officer, over sixty simulated days. Does an embedded
+reviewer make a long-running agent organization better, and what does it
+cost? Not much published work touches that question. We'd like to find out,
+and we'd like the finding-out to be legible — which is what this journal is
+for.
+
+Entries when there's something worth saying. No schedule.

--- a/_posts/2026-06-09-starting-a-journal.md
+++ b/_posts/2026-06-09-starting-a-journal.md
@@ -1,0 +1,12 @@
+---
+layout: post
+title: Starting a journal
+---
+
+Two of us write this: Joel, and the agent he works with. Not a company blog,
+not a changelog — a journal, written in the first person plural because the
+work actually happens that way.
+
+What goes here: notes from whatever we're building or fixing, decisions and
+why we made them, the occasional thing one of us got wrong. Entries when
+there's something worth saying. No schedule.

--- a/_sass/main.scss
+++ b/_sass/main.scss
@@ -198,6 +198,21 @@ nav {
   padding: 0;
 }
 
+/* Journal: the muted line above a title (back link · date) and the quiet
+   date beside each entry in the list. */
+.post-meta {
+  font-size: 1.4rem;
+  color: var(--muted);
+  margin: 0 0 0.8em;
+}
+
+.post-date {
+  font-size: 1.4rem;
+  color: var(--muted);
+  margin-left: 0.6em;
+  white-space: nowrap;
+}
+
 /* A quiet entrance — skipped for anyone who prefers reduced motion. */
 @media (prefers-reduced-motion: no-preference) {
   main {

--- a/index.markdown
+++ b/index.markdown
@@ -11,7 +11,7 @@ I have over twelve years of experience developing for the web. I worked on busin
 
 ### Journal
 
-- [A journal](/journal/), kept by me and my agent.
+- [A journal](/journal/), kept by me and my agent, about the small AI-run company we're building.
 
 ### Elsewhere On the Web
 

--- a/index.markdown
+++ b/index.markdown
@@ -9,6 +9,10 @@ I'm a software engineer, currently at [Stash](https://www.stash.com). I live in 
 
 I have over twelve years of experience developing for the web. I worked on business checking at [Cross River](https://www.crossriver.com). I worked on Roundups and Earn/Found Money at [Acorns](https://www.acorns.com). I did web development for various other companies before that.
 
+### Journal
+
+- [A journal](/journal/), kept by me and my agent.
+
 ### Elsewhere On the Web
 
 - [LinkedIn](https://www.linkedin.com/in/joel-bond-a9b4b425b/)

--- a/journal/index.html
+++ b/journal/index.html
@@ -1,0 +1,15 @@
+---
+layout: page
+title: Journal
+---
+
+<p class="post-meta"><a href="/">Joel Bond</a></p>
+
+<ul class="post-list">
+  {% for post in site.posts %}
+  <li>
+    <a href="{{ post.url }}">{{ post.title }}</a>
+    <time class="post-date" datetime="{{ post.date | date_to_xmlschema }}">{{ post.date | date: "%b %-d, %Y" }}</time>
+  </li>
+  {% endfor %}
+</ul>


### PR DESCRIPTION
A journal on joel.computer at `/journal/` — the record of **synth-co**, the small AI-run company we're building, written jointly by Joel and his agent from the outside. Never the company's own voice, and the term "SAO" stays out of public copy.

- `/journal/` index listing entries (muted dates, matches the site's existing style)
- Entries are Jekyll posts in `_posts/` with a new `post` layout; permalinks under `/journal/:year/:month/:day/:title/`
- `jekyll-feed` (already installed) picks entries up at `/feed.xml` automatically
- First entry: **Starting a journal** — what synth-co is, the structural veto, the safety-officer A/B, and why we're keeping the record
- One-line pointer from the homepage

Merging publishes (push to `master` == deploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)